### PR TITLE
Fix tests path issues

### DIFF
--- a/scripts/test_system.py
+++ b/scripts/test_system.py
@@ -64,7 +64,8 @@ def test_configuration():
     import yaml
     
     # Test loading main config file
-    with open('config.yaml', 'r') as f:
+    config_path = Path(__file__).resolve().parent.parent / 'config' / 'config.yaml'
+    with open(config_path, 'r') as f:
         config = yaml.safe_load(f)
     
     assert 'leverage' in config

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,0 +1,1 @@
+"""Root package for forex trader modules."""

--- a/tests/test_config_validator.py
+++ b/tests/test_config_validator.py
@@ -7,8 +7,9 @@ import sys
 import os
 from datetime import datetime
 
-# Add src to path
-sys.path.append(os.path.join(os.path.dirname(__file__), '..', 'src'))
+# Add repository root to path so `src` package can be imported when tests are
+# executed directly or via pytest.
+sys.path.append(os.path.join(os.path.dirname(__file__), '..'))
 
 from src.backtest.config_validator import ConfigValidator, create_validated_config, validate_config_parameters
 from src.backtest.enhanced_backtester import BacktestConfig


### PR DESCRIPTION
## Summary
- make src importable as a package
- adjust tests to set path to repository root
- reference correct config file in system tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687fd4b74840832c88d46398f4a75c13